### PR TITLE
review findings - nil fix

### DIFF
--- a/internal/controllers/topology/cluster/structuredmerge/dryrun.go
+++ b/internal/controllers/topology/cluster/structuredmerge/dryrun.go
@@ -33,9 +33,6 @@ import (
 // server side apply operations for the topology controller.
 func getTopologyManagedFields(original client.Object) map[string]interface{} {
 	r := map[string]interface{}{}
-	if reflect.ValueOf(original).IsValid() && reflect.ValueOf(original).IsNil() {
-		return r
-	}
 
 	for _, m := range original.GetManagedFields() {
 		if m.Operation == metav1.ManagedFieldsOperationApply &&

--- a/internal/controllers/topology/cluster/structuredmerge/twowayspatchhelper.go
+++ b/internal/controllers/topology/cluster/structuredmerge/twowayspatchhelper.go
@@ -233,7 +233,7 @@ func isNil(i interface{}) bool {
 	}
 	switch reflect.TypeOf(i).Kind() {
 	case reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice:
-		return reflect.ValueOf(i).IsNil()
+		return reflect.ValueOf(i).IsValid() && reflect.ValueOf(i).IsNil()
 	}
 	return false
 }


### PR DESCRIPTION
With this fix we handle all cases of nil the same way

we dropped the nil check in getTopologyManagedFields as we never call it with nil (see the switch on the call site)
